### PR TITLE
spcodinggoat/ta 11 complete inventory turnover rate

### DIFF
--- a/src/client/dashboard/Dashboard.jsx
+++ b/src/client/dashboard/Dashboard.jsx
@@ -16,22 +16,9 @@ import {
   Cell,
 } from 'recharts';
 import FeatureCard from '../components/FeatureCard';
-import { fetchInventoryMovements } from '../lib/data.js';
+import { fetchInventoryMovements, fetchTurnOverRate } from '../lib/data.js';
 
 const Dashboard = () => {
-  // Sample data structure - replace with actual data from your queries
-  const sampleMovementData = [
-    { month: '2024-01', purchase: 50000, usage: 45000 },
-    { month: '2024-02', purchase: 55000, usage: 48000 },
-    { month: '2024-03', purchase: 48000, usage: 52000 },
-  ];
-
-  const sampleTurnoverData = [
-    { month: '2024-01', turnover_rate: 85 },
-    { month: '2024-02', turnover_rate: 90 },
-    { month: '2024-03', turnover_rate: 88 },
-  ];
-
   const sampleTopIngredients = [
     { name: 'Flour', value: 2500 },
     { name: 'Sugar', value: 2000 },
@@ -63,12 +50,12 @@ const Dashboard = () => {
     fetchingInvMovement,
   } = fetchInventoryMovements();
 
-  console.log(
-    pendingInvMovement,
-    errorInvMovement,
-    invMovementData,
-    fetchingInvMovement,
-  );
+  const {
+    pendingTurnOverRate,
+    errorTurnOverRate,
+    dataTurnOverRate,
+    fetchingTurnOverRate,
+  } = fetchTurnOverRate();
 
   return (
     <div className='flex flex-col gap-4 p-4'>
@@ -91,10 +78,15 @@ const Dashboard = () => {
       <FeatureCard title='Inventory Turnover Rate'>
         <div className='h-64'>
           <ResponsiveContainer width='100%' height='100%'>
-            <LineChart data={sampleTurnoverData}>
+            <LineChart data={dataTurnOverRate && dataTurnOverRate}>
               <CartesianGrid strokeDasharray='3 3' />
               <XAxis dataKey='month' />
-              <YAxis />
+              <YAxis
+                dataKey='turnover_rate'
+                type='number'
+                padding={{ bottom: 10 }}
+                domain={[-150, 0]}
+              />
               <Tooltip />
               <Line
                 type='monotone'

--- a/src/client/lib/data.js
+++ b/src/client/lib/data.js
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
+import { dateYearMonthFormatter } from './lib';
 
 export const createNewProduct = async (product) => {
   try {
@@ -209,10 +210,7 @@ export const fetchInventoryMovements = () => {
         'http://localhost:3000/get/inventory-movement',
       );
 
-      return response.data.map((el) => {
-        const copy = { ...el, month: el.month.split('T')[0] };
-        return copy;
-      });
+      return response.data.map((el) => dateYearMonthFormatter(el));
     },
   });
   return {
@@ -220,5 +218,23 @@ export const fetchInventoryMovements = () => {
     errorInvMovement: error,
     invMovementData: data,
     fetchingInvMovement: isFetching,
+  };
+};
+
+export const fetchTurnOverRate = () => {
+  const { isPending, error, data, isFetching } = useQuery({
+    queryKey: ['turnOverRate'],
+    queryFn: async () => {
+      const response = await axios.get(
+        'http://localhost:3000/get/turn-over-rate',
+      );
+      return response.data.map((el) => dateYearMonthFormatter(el));
+    },
+  });
+  return {
+    pendingTurnOverRate: isPending,
+    errorTurnOverRate: error,
+    dataTurnOverRate: data,
+    fetchingTurnOverRate: isFetching,
   };
 };

--- a/src/client/lib/lib.js
+++ b/src/client/lib/lib.js
@@ -1,0 +1,5 @@
+export const dateYearMonthFormatter = (obj) => {
+  const date = obj.month.split('T')[0];
+  const month = date.slice(0, -3);
+  return { ...obj, month: month };
+};

--- a/src/server/routes/dashboardRoute.js
+++ b/src/server/routes/dashboardRoute.js
@@ -1,9 +1,13 @@
 import Router from 'express';
-import { getInventoryMovements } from '../db/queries.js';
+import { getInventoryMovements, getTurnOverRate } from '../db/queries.js';
 export const dashBoardRouter = Router();
 
 dashBoardRouter.get('/get/inventory-movement', async (req, res, next) => {
   const response = await getInventoryMovements();
-  // console.log(response);
+  res.send(response);
+});
+
+dashBoardRouter.get('/get/turn-over-rate', async (req, res, next) => {
+  const response = await getTurnOverRate();
   res.send(response);
 });


### PR DESCRIPTION
## Description

Completes the all the necessary steps from creating an endpoint and get the data from the db, to fetching them in the client and displaying them in dashboard view.

### What's Changed

- Creates the query to provide the necessary data from the db to the endpoint. Relates to TA-11.

- Creates the endpoint 'get/turn-over-rate' to serve the data to the client. Relates to TA-11.

- Creates the client side query to fetch the data from the server, also creates a fuc to convert the date from ISO 8601 timestamp format to 'yyyy-mm'. Relates to TA-11.

- Implement the "real" data in the Inventory Turnover Rate chart and makes some changes to better display the data. Closes TA-11.

### Related Issues

- Fixes #TA-11

### Type of Change

- [x] New feature

### Testing

- [x] I've tested these changes locally

### Screenshots

[Add screenshots if your changes include visual updates]

### Checklist

- [x] I've reviewed my own code
- [x] I've tested all the main features
- [x] I've updated documentation if needed
